### PR TITLE
Refine GameManager lifecycle safety and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,11 @@ A small Unity FPS-style ear-training game. You aim a turret, listen to a target 
 
 - Voice “processing pill” **removed** (design decision).  
 - Dud missile & shield bubble **implemented**.  
-- End screen flow **implemented** (pause, cursor unlock, buttons wired).  
+- End screen flow **implemented** (pause, cursor unlock, buttons wired).
 - Known polish items in **AI_HINTS.md**.
+
+## CHANGELOG
+
+- Align `GameManager` stats counters with the HUD display data and removed unused fields to keep end-screen summaries accurate.
+- Replaced Unity object null propagation with explicit checks to respect Unity's overloaded null semantics.
+- Guarded the death coroutine so the end screen still appears if the manager is disabled when game over triggers.


### PR DESCRIPTION
## Summary
- remove unused run statistic fields and align RunStats with the HUD counters
- replace Unity null-conditional usage with explicit checks and guard the death coroutine when the manager is disabled
- document the adjustments in the README changelog

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dae1adde208329972ce16a876021b0